### PR TITLE
iOS support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,10 @@ jobs:
         - name: Android64
           os: ubuntu-latest
           target: Android64
+        
+        - name: iOS
+          os: macos-latest
+          target: iOS
 
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build the mod
         uses: geode-sdk/build-geode-mod@main
         with:
-          bindings: weebifying/bindings
+          bindings: geode-sdk/bindings
           build-config: RelWithDebInfo
           combine: true
           sdk: 'nightly'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.21)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "iOS" OR IOS)
+    set(CMAKE_OSX_ARCHITECTURES "arm64")
+else()
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+endif()
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 project(LevelInfoinPauseMenu VERSION 1.1.0)

--- a/mod.json
+++ b/mod.json
@@ -1,9 +1,10 @@
 {
-	"geode": "4.0.0-beta.1",
+	"geode": "4.4.0",
 	"gd": {
 		"win": "2.2074",
 		"android": "2.2074",
-		"mac": "2.2074"
+		"mac": "2.2074",
+		"ios": "2.2074"
 	},
 	"version": "v1.1.0",
 	"id": "weebify.level_info_in_pause_menu",
@@ -11,13 +12,9 @@
 	"developer": "Weebify",
 	"description": "Adds the level info button to the pause menu",
 	"tags": ["interface", "utility"],
-	"dependencies": [
-		{
-			"id": "geode.node-ids",
-			"version": ">=1.17.0",
-			"importance": "required"
-		}
-	],
+	"dependencies": {
+		"geode.node-ids": ">=v1.17.0"
+	},
 	"resources": {
 		"sprites": [
 			"./image.png"


### PR DESCRIPTION
Bindings now pull from the geode-sdk bindings, dependency syntax now matches the 4.2/4.3+ formatting. 

You are also currently building using RelWithDebInfo, so if you want to cut down on file size, you could get rid of that line in build actions. 